### PR TITLE
Allow component containers to both overflow and fill

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -5,8 +5,9 @@
 }
 
 section {
-    // !IMPORTANT! The following forces flex layout to "fill" all routed components to rest of available space in page!
+    // !IMPORTANT! This establishes overflow for "content" sections for each component.
+    height: 100%;
     display: flex;
-    flex-direction: column;
     overflow-y: scroll;
+    overflow-x: hidden;
 }

--- a/src/components/demos/demo/demo.component.html
+++ b/src/components/demos/demo/demo.component.html
@@ -1,1 +1,6 @@
-<p>demo page works!</p>
+<div class="container">
+    <main>
+        <h1>Demo's Section</h1>
+    </main>
+</div>
+

--- a/src/components/demos/demo/demo.component.scss
+++ b/src/components/demos/demo/demo.component.scss
@@ -1,0 +1,1 @@
+@use "../../../scss/content-section";

--- a/src/components/home/home.component.scss
+++ b/src/components/home/home.component.scss
@@ -1,24 +1,26 @@
-.container {
-    color: var(--text);
+@use "../../scss/content-section";
 
-    main {
-        align-items: center;
-        display: flex;
-        flex-direction: column;
-        background-color: var(--background);
+// .container {
+//     color: var(--text);
 
-        h1 {
-            font-size: 70px; // TODO: create a series of fonts rem font sizes for h1, h2, etc. and apply them here.
-        }
+//     main {
+//         align-items: center;
+//         display: flex;
+//         flex-direction: column;
+//         background-color: var(--background);
 
-        h2 {
-            font-size: 40px;
-        }
+//         h1 {
+//             font-size: 70px; // TODO: create a series of fonts rem font sizes for h1, h2, etc. and apply them here.
+//         }
 
-        p {
-            text-indent: 5ch;
-            max-width: 70ch;
-        }
-    }
+//         h2 {
+//             font-size: 40px;
+//         }
 
-}
+//         p {
+//             text-indent: 5ch;
+//             max-width: 70ch;
+//         }
+//     }
+
+// }

--- a/src/scss/_content-section.scss
+++ b/src/scss/_content-section.scss
@@ -1,0 +1,35 @@
+// Creates a "content" section for all components to inherit from, so that their content will fill exactly
+// the same in every route.
+
+:host {
+    display: flex;
+}
+
+.container {
+    color: var(--text);
+    background: var(--background);
+    width: 100vw; //!important to stretch out the rows for centered content
+    overflow-x: hidden;
+    display: flex;
+
+    main {
+        background-color: var(--background);
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        flex: 1 0 100%;
+
+        h1 {
+            font-size: 70px; // TODO: create a series of fonts rem font sizes for h1, h2, etc. and apply them here.
+        }
+
+        h2 {
+            font-size: 40px;
+        }
+
+        p {
+            text-indent: 5ch;
+            max-width: 70ch;
+        }
+    }
+}


### PR DESCRIPTION
* Component containers will now either overflow based on content provided, or fill the remaining gaps in the empty space left in the container element.
* My brain hurts from trying to get this right.